### PR TITLE
Changed so height is handled by flex insetad of media queries

### DIFF
--- a/src/containers/Admin/styles.scss
+++ b/src/containers/Admin/styles.scss
@@ -39,6 +39,9 @@
         color: var(--tavla-font-color);
         border-color: var(--tavla-button-background-color);
         width: 12rem;
+        min-height: 3rem;
+        height: auto;
+        flex: 1;
     }
 
     .eds-tab:hover {
@@ -69,13 +72,6 @@
     .eds-tab-panel:focus,
     .eds-tab:focus {
         outline: none;
-    }
-}
-
-@media (max-width: 1140px) {
-    .eds-tab {
-        min-width: 10rem;
-        padding-bottom: 3.5rem;
     }
 }
 


### PR DESCRIPTION
"height:auto" means that height should be handled by flexbox and "flex:1" means that each tab should take up as much space as the others and stretch accordingly